### PR TITLE
Remove the rolling.ignored file.

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,1 +1,0 @@
-kdl_parser_py


### PR DESCRIPTION
We have now migrated kdl_parser_py to a separate repository, so no need for this file anymore.